### PR TITLE
fix: lab 5: make sure placeholder is aligned to 4 KiB page in PFH2

### DIFF
--- a/src/lab5/user/main.c
+++ b/src/lab5/user/main.c
@@ -44,7 +44,7 @@ int main() {
 
 /* PFH main #2 */
 #elif defined(PFH2)
-char global_placeholder[0x1000];
+char __attribute__((aligned(0x1000))) global_placeholder[0x1000];
 unsigned long global_increment = 0;
 
 int main() {


### PR DESCRIPTION
在一些 gcc 版本下，Lab 5 的 PFH2 测试点中，编译器会将 global_increment 和 global_placeholder 的顺序重新排布. 这样一来，global_placeholder 并不是独占一整页空间，导致难以观测到实验文档中 create_mapping “缺少一页” 的现象.

> `make run TEST=PFH2` 的效果与前面类似，只不过它通过全局变量空出了一整页大小的未使用 .data 区域，这段区域在运行的时候也不会触发 page fault，所以在 log 中应该可以发现 create_mapping 映射的虚拟地址空间会缺少一页。

这个 PR 通过添加 `__attribute__((aligned(0x1000)))` 告知 gcc 编译器应当让 global_placeholder 对齐到一整页，以确保文档中描述的现象（如果实现正确的话）能够出现.

我的测试环境:

```bash
riscv64-unknown-linux-gnu-gcc (GCC) 13.3.0
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

使用 `nm` 查看 gcc 对变量的编排:
```
00000000000133f8 B __BSS_END__
0000000000012000 B __bss_start
0000000000013010 B buffer
0000000000012000 R __DATA_BEGIN__
0000000000012000 R _edata
00000000000133f8 B _end
00000000000100ec t getpid
0000000000012000 B global_increment
0000000000012010 B global_placeholder
0000000000012800 A __global_pointer$
000000000001023c T isspace
0000000000011200 r lowerxdigits.0
0000000000010174 T main
0000000000010594 t print_dec_int
00000000000110a0 T printf
00000000000101d4 T putc
000000000001050c t puts_wo_nl
0000000000012000 R __SDATA_BEGIN__
00000000000100e8 T _start
000000000001029c T strtol
0000000000012008 B tail
00000000000111e8 r upperxdigits.1
00000000000108a0 T vprintfmt
0000000000010120 T wait
```
可以发现 global_placeholder 的位置是 `[0x12010, 0x13010)` 横跨了两页，而程序既会用到前一页位于 0x12000 的 global_increment，也会用到后一页位于 0x13010 的 buffer，所以两页都会被加载并 create_mapping.

使用 gcc 14.2.0 版本时不会出现该问题，因为 gcc 14.2.0 会把 global_placeholder 放在 `[0x13000, 0x14000)`，而 global_increment 在 0x12000 处.
